### PR TITLE
fix renderflow issue on ios

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -199,20 +199,20 @@ class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
                 alignment: Alignment.bottomRight,
                 children: <Widget>[
                   IntrinsicWidth(
-                    child: FittedBox(
                       child: Column(crossAxisAlignment: CrossAxisAlignment.start,
                         mainAxisSize: MainAxisSize.min,
                         children: <Widget>[
                           ValidationItem("8 characters", eightChars),
                           _separator(),
-                          ValidationItem("1 special character", specialChar),
+                          FittedBox(
+                            child: ValidationItem("1 special character", specialChar),
+                          ),
                           _separator(),
                           ValidationItem("1 upper case", upperCaseChar),
                           _separator(),
                           ValidationItem("1 number", number)
                         ],
                       )
-                    ),
                   ),
                   Padding(
                     padding: const EdgeInsets.all(8.0),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -199,18 +199,19 @@ class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
                 alignment: Alignment.bottomRight,
                 children: <Widget>[
                   IntrinsicWidth(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      mainAxisSize: MainAxisSize.min,
-                      children: <Widget>[
-                        ValidationItem("8 characters", eightChars),
-                        _separator(),
-                        ValidationItem("1 special character", specialChar),
-                        _separator(),
-                        ValidationItem("1 upper case", upperCaseChar),
-                        _separator(),
-                        ValidationItem("1 number", number)
-                      ],
+                    child: FittedBox(
+                      child: Column(crossAxisAlignment: CrossAxisAlignment.start,
+                        mainAxisSize: MainAxisSize.min,
+                        children: <Widget>[
+                          ValidationItem("8 characters", eightChars),
+                          _separator(),
+                          ValidationItem("1 special character", specialChar),
+                          _separator(),
+                          ValidationItem("1 upper case", upperCaseChar),
+                          _separator(),
+                          ValidationItem("1 number", number)
+                        ],
+                      )
                     ),
                   ),
                   Padding(


### PR DESCRIPTION
Great repo !!

I observed a renderflow exception on iOS simulator (iphone 8 - 11.4) as below:

![screen shot 2019-03-04 at 4 19 16 pm](https://user-images.githubusercontent.com/16548367/53730084-e6d43d00-3e9c-11e9-9837-de2c65b8c5f9.png)

I fixed it by wrapping the `Column` widget that contains `ValidatonItems` around `FittedBox` that scales and positions its child according to the fit.  Updated screenshot below:

![screen shot 2019-03-04 at 4 30 10 pm](https://user-images.githubusercontent.com/16548367/53730142-1420eb00-3e9d-11e9-94d6-12c53d1e7531.png)

